### PR TITLE
Feat: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/registry.yaml
+++ b/.github/workflows/registry.yaml
@@ -19,12 +19,12 @@ jobs:
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             VERSION=latest
           fi
-          echo ::set-output name=VERSION::${VERSION}
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
       - name: Get git revision
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=git_revision::$(git rev-parse --short HEAD)"
+          echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login ghcr.io
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
## Description

Closes #2 

Update `.github/workflows/registry.yaml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=VERSION::${VERSION}
```

```yaml
echo "::set-output name=git_revision::$(git rev-parse --short HEAD)"
```

**TO-BE**

```yaml
echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
```

```yaml
echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
```